### PR TITLE
Fix for loop off by one error

### DIFF
--- a/src/flow/loops/for.md
+++ b/src/flow/loops/for.md
@@ -5,7 +5,7 @@ For loops are the other core type of loop in DM.
 There's two main syntaxes for iteration, one traditional and one cleaner:
 
 ```dm
-for (var/x = 0; x < 10; x++)
+for (var/x = 0; x <= 10; x++)
 	...
 
 for (var/x in 0 to 10)


### PR DESCRIPTION
The two for loop examples on the `for.dm` page weren't equivalent, they are now.